### PR TITLE
Fix: 어드민 페이지에서 그룹 상세조회 가능

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     permissions:
       contents: read
       security-events: write
@@ -91,10 +92,21 @@ jobs:
       # ──────────────────────────────
       # Trivy (filesystem scan) → SARIF
       # ──────────────────────────────
+      - name: Install Trivy
+        run: |
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/trusted.gpg.d/trivy.gpg > /dev/null
+          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" \
+            | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
+          trivy --version
+
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.34.1
         with:
           scan-type: fs
+          skip-setup-trivy: true
           ignore-unfixed: true
           severity: HIGH,CRITICAL
           format: sarif
@@ -168,9 +180,10 @@ jobs:
 
       - name: Trivy image scan
         if: ${{ steps.df.outputs.found == 'true' }}
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.34.1
         with:
           scan-type: image
+          skip-setup-trivy: true
           image-ref: local/lms-front:secscan
           ignore-unfixed: true
           severity: HIGH,CRITICAL

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -199,6 +199,34 @@
   align-items: center;
 }
 
+/* 어드민 상세 보기 버튼 스타일 */
+.admin-view-btn {
+  padding: 8px 16px;
+  border-radius: 20px;
+  border: none;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #28a745, #218838);
+  color: white;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  box-shadow: 0 2px 8px rgba(40, 167, 69, 0.3);
+  min-width: 70px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.admin-view-btn:hover {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 4px 15px rgba(40, 167, 69, 0.4);
+  background: linear-gradient(135deg, #218838, #1e7e34);
+}
+
+.admin-view-btn:active {
+  transform: translateY(0) scale(0.98);
+  box-shadow: 0 2px 8px rgba(40, 167, 69, 0.3);
+}
+
 /* 어드민 삭제 버튼 스타일 */
 .admin-delete-btn {
   padding: 8px 16px;
@@ -437,6 +465,17 @@
 .dark .status-toggle-container.inactive .toggle-switch {
   background: rgba(255, 255, 255, 0.15);
   border-color: rgba(255, 255, 255, 0.3);
+}
+
+.dark .admin-view-btn {
+  background: linear-gradient(135deg, #28a745, #218838);
+  color: var(--black);
+  box-shadow: 0 2px 8px rgba(40, 167, 69, 0.4);
+}
+
+.dark .admin-view-btn:hover {
+  background: linear-gradient(135deg, #218838, #1e7e34);
+  box-shadow: 0 4px 15px rgba(40, 167, 69, 0.5);
 }
 
 .dark .admin-delete-btn {

--- a/src/components/groups/GroupDetail.jsx
+++ b/src/components/groups/GroupDetail.jsx
@@ -186,33 +186,34 @@ export default function GroupDetail({ groupId, myStudies }) {
       setIsMentor(false);
       return;
     }
-    
+
     try {
-      // /group/{groupId}/member API를 사용해서 멤버 목록과 역할 확인
       const res = await api('GET', `/group/${groupId}/member`, null, token);
       const members = res?.data || [];
-      
+
+      // 멘토 정보 추출
+      const mentor = members.find(member => member.role === 'MENTOR');
+      setMentorInfo(mentor);
+
+      // 어드민은 모든 그룹에 대해 멘토 권한으로 표시
+      if (user?.role === 'ROLE_ADMIN') {
+        setIsMentor(true);
+        return;
+      }
+
       // 현재 사용자가 멘토인지 확인
       const myStudentNo = (user?.studentNumber ?? '').toString();
       const myEmail = (user?.email ?? '').toLowerCase();
-      
+
       const myMemberInfo = members.find(member => {
         const memberStudent = (member?.studentNumber ?? '').toString();
         const memberEmail = (member?.email ?? '').toLowerCase();
         return (!!myStudentNo && myStudentNo === memberStudent) || (!!myEmail && !!memberEmail && myEmail === memberEmail);
       });
-      
-      // 멤버 정보에서 role이 MENTOR인지 확인
-      const isMentor = myMemberInfo?.role === 'MENTOR';
-      setIsMentor(isMentor);
-      
-      // 멘토 정보 추출
-      const mentor = members.find(member => member.role === 'MENTOR');
-      setMentorInfo(mentor);
-      
+
+      setIsMentor(myMemberInfo?.role === 'MENTOR');
+
     } catch {
-      // 멘토 권한 확인 오류 처리
-      // 에러 발생 시 사용자 role로 판단
       if (user?.role === 'ROLE_ADMIN' || user?.role === 'ROLE_MENTOR') {
         setIsMentor(true);
       } else {

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -782,13 +782,21 @@ useEffect(() => {
                         </td>
                         <td>
                           <div className="admin-table-actions">
+                            {/* 상세 보기 버튼 */}
+                            <button
+                              className="admin-view-btn"
+                              onClick={() => nav(`/groups?groupId=${g.studyGroupId}`)}
+                            >
+                              <i className="fas fa-eye"></i>
+                              상세 보기
+                            </button>
                             {/* 삭제 버튼 */}
                             <button
                               className="admin-delete-btn"
-                              onClick={() => setDeleteModal({ 
-                                isOpen: true, 
-                                groupName: g.name, 
-                                groupId: g.studyGroupId 
+                              onClick={() => setDeleteModal({
+                                isOpen: true,
+                                groupName: g.name,
+                                groupId: g.studyGroupId
                               })}
                             >
                               <i className="fas fa-trash-alt"></i>

--- a/src/pages/Group.jsx
+++ b/src/pages/Group.jsx
@@ -44,7 +44,8 @@ export default function Group() {
 
     const fetchUserGroups = async () => {
       try {
-        const res = await api('GET', '/group/all', null, token);
+        const endpoint = user?.role === 'ROLE_ADMIN' ? '/admin/group/all' : '/group/all';
+        const res = await api('GET', endpoint, null, token);
         
         const groups = res?.data || [];
         const mapped = groups.map(g => ({


### PR DESCRIPTION
상세보기 추가

<img width="198" height="195" alt="image" src="https://github.com/user-attachments/assets/68f34d22-09c3-4d84-bf9c-5746def68d0b" />

이런 식으로 상세보기를 할 수 있도록 수정했습니다.
해당 버튼 클릭시 해당 스터디 페이지로 넘어갑니다.

<img width="1044" height="950" alt="image" src="https://github.com/user-attachments/assets/b73f12f8-8640-41e0-947f-24b6dc5eb6db" />

---

+백엔드랑 똑같이 trivy scan 업데이트 오류 나와서 함께 수정했습니다

